### PR TITLE
feat: Add 'Open in [Source]' button for iCal bookings

### DIFF
--- a/src/app/(dashboard)/bookings/[id]/page.tsx
+++ b/src/app/(dashboard)/bookings/[id]/page.tsx
@@ -11,6 +11,7 @@ import PaymentButton from '@/components/PaymentButton';
 import CheckInStatusBadge from '@/components/CheckInStatusBadge';
 import CheckInDetails from '@/components/CheckInDetails';
 import ManualCheckInButton from '@/components/ManualCheckInButton';
+import { extractReservationUrl } from '@/utils/stringUtils';
 
 export default async function BookingDetailPage({ params }: { params: { id: string } }) {
   const session = await getServerSession();
@@ -97,6 +98,8 @@ export default async function BookingDetailPage({ params }: { params: { id: stri
     }
   };
   
+  const reservationUrl = extractReservationUrl(booking.notes);
+  
   return (
     <div className="space-y-6">
       <div className="flex justify-between items-center">
@@ -138,7 +141,7 @@ export default async function BookingDetailPage({ params }: { params: { id: stri
               size="md"
             />
             {booking.status === 'confirmed' && booking.paymentStatus === 'paid' && !booking.hasCheckedIn && (
-              <div className="mt-2">
+              <div className="mt-2 flex space-x-2">
                 <ManualCheckInButton 
                   bookingId={params.id}
                   bookingDetails={{
@@ -147,6 +150,16 @@ export default async function BookingDetailPage({ params }: { params: { id: stri
                     apartmentName: apartment?.name || 'Appartamento'
                   }}
                 />
+                {booking.source !== 'direct' && reservationUrl && (
+                  <a
+                    href={reservationUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="bg-purple-600 text-white px-4 py-2 rounded-md hover:bg-purple-700"
+                  >
+                    Apri in {booking.source ? booking.source.charAt(0).toUpperCase() + booking.source.slice(1) : 'link'}
+                  </a>
+                )}
               </div>
             )}
           </div>

--- a/src/utils/__tests__/stringUtils.test.ts
+++ b/src/utils/__tests__/stringUtils.test.ts
@@ -1,0 +1,76 @@
+// src/utils/__tests__/stringUtils.test.ts
+import { extractReservationUrl } from '../stringUtils';
+
+describe('extractReservationUrl', () => {
+  // Test case 1: Input string contains a valid HTTPS URL
+  test('should return the HTTPS URL when present', () => {
+    const notes = 'Please find the reservation details at https://example.com/booking/123';
+    expect(extractReservationUrl(notes)).toBe('https://example.com/booking/123');
+  });
+
+  // Test case 2: Input string contains a valid HTTP URL
+  test('should return the HTTP URL when present', () => {
+    const notes = 'Link: http://example.com/reservation/abc';
+    expect(extractReservationUrl(notes)).toBe('http://example.com/reservation/abc');
+  });
+
+  // Test case 3: Input string contains multiple URLs
+  test('should return the first URL when multiple are present', () => {
+    const notes = 'Main link: https://main-example.com. Secondary: http://secondary-example.com';
+    expect(extractReservationUrl(notes)).toBe('https://main-example.com');
+  });
+
+  // Test case 4: Input string does not contain any URL
+  test('should return null when no URL is present', () => {
+    const notes = 'This is a note without any URL.';
+    expect(extractReservationUrl(notes)).toBeNull();
+  });
+
+  // Test case 5: Input string is empty
+  test('should return null when the string is empty', () => {
+    const notes = '';
+    expect(extractReservationUrl(notes)).toBeNull();
+  });
+
+  // Test case 6: Input string is null
+  test('should return null when the string is null', () => {
+    const notes = null;
+    expect(extractReservationUrl(notes)).toBeNull();
+  });
+
+  // Test case 6a: Input string is undefined
+  test('should return null when the string is undefined', () => {
+    const notes = undefined;
+    expect(extractReservationUrl(notes)).toBeNull();
+  });
+
+  // Additional test: URL at the beginning of the string
+  test('should return the URL when it is at the beginning of the string', () => {
+    const notes = 'http://start.com has the details';
+    expect(extractReservationUrl(notes)).toBe('http://start.com');
+  });
+
+  // Additional test: URL at the end of the string
+  test('should return the URL when it is at the end of the string', () => {
+    const notes = 'Details are at https://end.com';
+    expect(extractReservationUrl(notes)).toBe('https://end.com');
+  });
+
+  // Additional test: URL with query parameters
+  test('should return the URL with query parameters', () => {
+    const notes = 'Check https://example.com/path?param1=value1&param2=value2';
+    expect(extractReservationUrl(notes)).toBe('https://example.com/path?param1=value1&param2=value2');
+  });
+
+  // Additional test: URL with a fragment identifier
+  test('should return the URL with a fragment identifier', () => {
+    const notes = 'See section https://example.com/page#section-3';
+    expect(extractReservationUrl(notes)).toBe('https://example.com/page#section-3');
+  });
+
+  // Additional test: String with only a URL
+  test('should return the URL when the string is just a URL', () => {
+    const notes = 'https://only-url.com';
+    expect(extractReservationUrl(notes)).toBe('https://only-url.com');
+  });
+});

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -1,0 +1,15 @@
+// src/utils/stringUtils.ts
+
+/**
+ * Extracts the first URL (starting with http:// or https://) from a string.
+ * @param text The string to search for a URL.
+ * @returns The first URL found, or null if no URL is found or the input is invalid.
+ */
+export const extractReservationUrl = (text: string | undefined | null): string | null => {
+  if (!text) {
+    return null;
+  }
+  const urlRegex = /(https?:\/\/[^\s]+)/;
+  const match = text.match(urlRegex);
+  return match ? match[0] : null;
+};


### PR DESCRIPTION
This commit introduces a new button on the booking details page that allows you to directly open the reservation on the original platform (e.g., Airbnb, Booking.com) if the booking was imported via iCal and contains a reservation URL in its notes.

Key changes:
- Added an `extractReservationUrl` helper function to parse URLs from booking notes. This function is now located in `src/utils/stringUtils.ts`.
- The booking details page (`src/app/(dashboard)/bookings/[id]/page.tsx`) now uses this function to find a reservation URL.
- An "Apri in [Source]" button is conditionally displayed if:
    - The booking source is not 'direct'.
    - A reservation URL is found in the booking notes.
- The button is styled with a distinct color and placed next to the "Check-in Manuale" button for easy access.
- Clicking the button opens the reservation URL in a new browser tab.
- Added comprehensive unit tests for the `extractReservationUrl` function in `src/utils/__tests__/stringUtils.test.ts`.
- Integration tests for the button rendering were not added due to the current lack of a testing framework for React components in the project.