### PR TITLE
Update booking guest name and email upon check-in

### DIFF
--- a/src/app/api/checkin/submit/route.ts
+++ b/src/app/api/checkin/submit/route.ts
@@ -136,29 +136,20 @@ export async function POST(req: NextRequest) {
         }
       }
 
-      // NUOVA LOGICA: Aggiorna i dati della prenotazione con i dati reali dell'ospite principale
-      // Solo se la prenotazione è stata importata (ha un email fittizia)
-      if (booking.guestEmail && booking.guestEmail.includes('@guest.example.com')) {
-        // Costruisci il nome completo dell'ospite principale
-        const mainGuestFullName = `${mainGuestData.firstName} ${mainGuestData.lastName}`;
-        
-        // Aggiorna i dati della prenotazione con i dati reali
-        booking.guestName = mainGuestFullName;
-        
-        // Aggiorna l'email con quella fornita durante il check-in
-        // Usa identificationEmail se disponibile (modalità normale), altrimenti originalEmail (modalità unassigned)
-        const emailToUse = identificationEmail || originalEmail;
-        if (emailToUse && emailToUse !== booking.guestEmail) {
-          booking.guestEmail = emailToUse;
+      // Logic to update booking with main guest's data
+      const mainGuestFullName = `${mainGuestData.firstName} ${mainGuestData.lastName}`;
+      booking.guestName = mainGuestFullName;
+
+      if (identificationEmail && identificationEmail.trim() !== "") {
+        if (booking.guestEmail !== identificationEmail) {
+          booking.guestEmail = identificationEmail;
         }
-        
-        // Se hai il telefono nei dati del guest, aggiornalo
-        // booking.guestPhone = mainGuestData.phone || booking.guestPhone;
-        
-        // Aggiungi una nota per tracciare l'aggiornamento
-        const updateNote = `Dati aggiornati dopo check-in online: ${mainGuestFullName}`;
-        booking.notes = booking.notes ? `${booking.notes}\n${updateNote}` : updateNote;
+      } else {
+        console.warn(`Attempted online check-in for booking ID ${booking._id} without a valid identificationEmail. Booking email not updated.`);
       }
+      
+      const updateNote = `Dati aggiornati dopo check-in online: ${mainGuestFullName}`;
+      booking.notes = booking.notes ? `${booking.notes}\n${updateNote}` : updateNote;
 
       booking.hasCheckedIn = true;
       await booking.save();


### PR DESCRIPTION
This commit implements the functionality to automatically update the guestName and guestEmail fields of a booking when a check-in is completed.

Modifications:

1.  Online Check-in (`/api/checkin/submit`):
    *   Removed the condition that limited updates to bookings with placeholder emails.
    *   Booking's `guestName` is now always updated with the main guest's full name from the check-in data.
    *   Booking's `guestEmail` is updated with the `identificationEmail` provided during the check-in process, if available. A warning is logged if `identificationEmail` is missing.

2.  Manual Check-in (`/api/checkin/manual`):
    *   Added logic to update `guestName` with the main guest's full name.
    *   Added logic to update `guestEmail` based on an `identificationEmail` field expected in the request body. A warning is logged if this email is not provided.
    *   Updated `booking.checkInDate` to use `checkIn.completedAt` for better consistency.

These changes ensure that booking details reflect the most current information provided by the guest during either the online or manual check-in process, as per your request.