### PR TITLE
Fix: Adjust calendar legend and notification dropdown z-index

### DIFF
--- a/src/components/MultiCalendarView.tsx
+++ b/src/components/MultiCalendarView.tsx
@@ -748,11 +748,12 @@ export default function MultiCalendarView({ apartments }: MultiCalendarViewProps
       {/* Legenda */}
       <div className="flex flex-wrap items-center gap-4 mb-4 hidden md:flex">
         <div className="flex items-center">
-          <div className="w-4 h-4 bg-green-100 border border-green-300 mr-2"></div> {/* Corrected border */}
-          <span>Prenotato (Confermato)</span>
+          <div className="w-4 h-4 bg-green-100 border border-green-300 mr-2"></div>
+          <span>Prenotato</span> {/* Label simplified */}
         </div>
         <div className="flex items-center">
-          <div className="w-4 h-4 bg-green-300 border border-green-500 mr-2"></div> {/* New item */}
+          <div className="w-4 h-4 bg-green-300 border border-green-500 mr-1"></div> {/* Margin reduced */}
+          <ClipboardDocumentCheckIcon className="w-4 h-4 text-green-700 mr-2" /> {/* Icon added, text color slightly darker for visibility on light backgrounds if any */}
           <span>Check-in Effettuato</span>
         </div>
         <div className="flex items-center">
@@ -771,10 +772,7 @@ export default function MultiCalendarView({ apartments }: MultiCalendarViewProps
           <div className="w-4 h-4 bg-indigo-100 border border-indigo-300 mr-2"></div>
           <span>Selezionato</span>
         </div>
-        <div className="flex items-center">
-          <ClipboardDocumentCheckIcon className="w-4 h-4 text-green-600 mr-1" />
-          <span>Check-in effettuato</span>
-        </div>
+        {/* Icon-only "Check-in effettuato" entry removed */}
       </div>
       
       {/* Calendario principale */}

--- a/src/components/NotificationDropdown.tsx
+++ b/src/components/NotificationDropdown.tsx
@@ -123,7 +123,7 @@ export default function NotificationDropdown({ isOpen, onClose }: NotificationDr
       leaveFrom="transform opacity-100 scale-100"
       leaveTo="transform opacity-0 scale-95"
     >
-      <div className="absolute right-0 z-10 mt-2 w-80 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
+      <div className="absolute right-0 z-40 mt-2 w-80 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
         <div className="px-4 py-3 border-b border-gray-200">
           <div className="flex items-center justify-between">
             <h3 className="text-sm font-semibold text-gray-900">Notifiche</h3>


### PR DESCRIPTION
This commit addresses two UI issues based on your feedback:
1.  Refines the legend in the multi-calendar for clarity.
2.  Fixes a z-index problem causing the notification dropdown to appear behind the multi-calendar.

Key changes:

1.  **Multi-Calendar Legend Update (`src/components/MultiCalendarView.tsx`):**
    *   The legend entry "Prenotato (Confermato)" has been simplified to "Prenotato".
    *   The visual cue for "Check-in Effettuato" has been consolidated:
        *   Removed the separate legend item that only showed the
          `ClipboardDocumentCheckIcon`.
        *   The legend item трубы (dark green square) now also includes the
          `ClipboardDocumentCheckIcon` directly next to it, with the
          single label "Check-in Effettuato".
        *   The icon color was slightly adjusted to `text-green-700` for
          better visibility if needed.

2.  **Notification Dropdown z-index (`src/components/NotificationDropdown.tsx`):**
    *   The `z-index` class for the main container of the notification
      dropdown has been increased from `z-10` to `z-40`.
    *   This ensures that the notification dropdown correctly renders on top
      of other page elements with lower stacking contexts, such as the
      sticky header and cells of the multi-calendar (which typically use
      `z-10` or `z-20`).

These changes improve the clarity of the calendar legend and resolve the visibility issue with the notification dropdown, leading to a better experience for you.