### PR TITLE
feat: Add user profile page and account reset functionality

### DIFF
--- a/src/app/(dashboard)/profile/page.tsx
+++ b/src/app/(dashboard)/profile/page.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useSession, signOut } from 'next-auth/react';
+import { useState } from 'react'; // Importa useState per gestire lo stato di caricamento/errore
+import toast from 'react-hot-toast'; // Assumendo l'uso di react-hot-toast per le notifiche
+
+export default function ProfilePage() {
+  const { data: session } = useSession();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleResetAccount = async () => {
+    const confirmation = window.confirm(
+      "Sei sicuro di voler ripristinare il tuo account? Tutti i dati (appartamenti, prenotazioni, check-in, impostazioni, ecc.) verranno eliminati permanentemente. Questa azione non può essere annullata."
+    );
+    if (confirmation) {
+      setIsLoading(true);
+      toast.loading('Ripristino dell_account in corso...', { id: 'reset-toast' }); // Mostra notifica di caricamento
+
+      try {
+        const response = await fetch('/api/account/reset', {
+          method: 'DELETE',
+        });
+
+        const result = await response.json();
+
+        if (response.ok) {
+          toast.success('Account ripristinato con successo! Tutti i dati sono stati cancellati.', { id: 'reset-toast' });
+          // Reindirizza l'utente o esegui il logout
+          // È consigliabile fare il logout e reindirizzare alla pagina di login
+          await signOut({ callbackUrl: '/login' });
+        } else {
+          toast.error(`Errore durante il ripristino: ${result.message || 'Errore sconosciuto'}`, { id: 'reset-toast' });
+        }
+      } catch (error) {
+        console.error('Errore nella chiamata API di ripristino:', error);
+        toast.error('Errore di connessione durante il ripristino dell_account.', { id: 'reset-toast' });
+      } finally {
+        setIsLoading(false);
+      }
+    } else {
+      console.log('Azione di ripristino annullata.');
+      toast.dismiss('reset-toast'); // Rimuovi la notifica se l'utente annulla mentre era in caricamento (improbabile qui ma buona pratica)
+    }
+  };
+
+  if (!session && !isLoading) { // Se non c'è sessione e non sta caricando il reset
+    return <p>Caricamento sessione...</p>;
+  }
+
+  if (isLoading && !session) { // Se sta resettando e la sessione è andata (dopo signOut)
+     return <p>Ripristino in corso... Sarai reindirizzato a breve.</p>;
+  }
+
+
+  return (
+    <div className="container mx-auto py-10">
+      <h1 className="text-2xl font-semibold mb-6">Profilo Utente</h1>
+      <div className="bg-white shadow rounded-lg p-6 mb-6">
+        <h2 className="text-xl font-semibold mb-4">Informazioni Utente</h2>
+        <p><strong>Nome:</strong> {session?.user?.name || 'Non disponibile'}</p>
+        <p><strong>Email:</strong> {session?.user?.email || 'Non disponibile'}</p>
+        {session?.user?.role && (
+          <p><strong>Ruolo:</strong> {session.user.role}</p>
+        )}
+      </div>
+
+      <div className="bg-white shadow rounded-lg p-6">
+        <h2 className="text-xl font-semibold mb-4">Gestione Account</h2>
+        <p className="mb-4 text-sm text-gray-600">
+          Attenzione: Il ripristino dell'account cancellerà permanentemente tutti i dati associati,
+          inclusi appartamenti, prenotazioni, check-in e impostazioni.
+          Questa azione non può essere annullata.
+        </p>
+        <button
+          className={`bg-red-600 hover:bg-red-700 text-white font-bold py-2 px-4 rounded ${isLoading ? 'opacity-50 cursor-not-allowed' : ''}`}
+          onClick={handleResetAccount}
+          disabled={isLoading} // Disabilita il pulsante durante il caricamento
+        >
+          {isLoading ? 'Ripristino in corso...' : 'Ripristina Account'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/account/reset/route.ts
+++ b/src/app/api/account/reset/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import connectDB from '@/lib/db';
+import ApartmentModel from '@/models/Apartment';
+import BookingModel from '@/models/Booking';
+import CheckInModel from '@/models/CheckIn';
+import DailyRateModel from '@/models/DailyRate';
+import NotificationModel from '@/models/Notification';
+import PublicProfileModel from '@/models/PublicProfile';
+import SettingsModel from '@/models/Settings';
+
+export async function DELETE(request: Request) {
+  const session = await getServerSession();
+
+  if (!session || !session.user) {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+  }
+
+  // Ulteriore controllo: solo un ruolo specifico può resettare?
+  // Per ora, assumiamo che qualsiasi utente loggato possa farlo,
+  // ma in produzione potresti voler limitare questa azione (es. solo 'admin').
+  // if (session.user.role !== 'admin') {
+  //   return NextResponse.json({ message: 'Forbidden' }, { status: 403 });
+  // }
+
+  try {
+    await connectDB();
+
+    // Array di promesse per tutte le operazioni di cancellazione
+    const deletionPromises = [
+      ApartmentModel.deleteMany({}),
+      BookingModel.deleteMany({}),
+      CheckInModel.deleteMany({}),
+      DailyRateModel.deleteMany({}),
+      NotificationModel.deleteMany({}), // Considera se vuoi cancellare le notifiche o meno
+      PublicProfileModel.deleteMany({}),
+      SettingsModel.deleteMany({})
+    ];
+
+    await Promise.all(deletionPromises);
+
+    return NextResponse.json({ message: 'Account reset successfully. All data has been deleted.' }, { status: 200 });
+
+  } catch (error) {
+    console.error('Error during account reset:', error);
+    let errorMessage = 'An unknown error occurred';
+    if (error instanceof Error) {
+        errorMessage = error.message;
+    }
+    return NextResponse.json({ message: 'Error resetting account.', error: errorMessage }, { status: 500 });
+  }
+}


### PR DESCRIPTION
Implementa una nuova pagina profilo utente accessibile da `/profile`. La pagina visualizza le tue informazioni utente (nome, email, ruolo) recuperate dalla sessione NextAuth.

Aggiunge una funzionalità di "Ripristina Account" che ti permette di cancellare tutti i dati associati al channel manager dal database. L'operazione richiede una tua conferma esplicita tramite un dialogo modale per prevenire cancellazioni accidentali.

Dettagli tecnici:
- Nuova pagina: `src/app/(dashboard)/profile/page.tsx`
- Nuovo API endpoint: `src/app/api/account/reset/route.ts` (metodo DELETE)
  - L'endpoint verifica l'autenticazione prima di procedere.
  - Cancella i dati dalle seguenti collezioni: Apartment, Booking, CheckIn, DailyRate, Notification, PublicProfile, Settings.
- La UI della pagina profilo include:
  - Visualizzazione dati utente.
  - Pulsante "Ripristina Account" con avviso sui dati che verranno cancellati.
  - Dialogo di conferma (`window.confirm`).
  - Feedback visivo (stato di caricamento, notifiche toast con `react-hot-toast`) durante l'operazione di ripristino.
  - Logout automatico e reindirizzamento alla pagina di login dopo un ripristino andato a buon fine.

Questa funzionalità ti fornisce un modo per ricominciare da zero con la configurazione del channel manager.